### PR TITLE
Don't panic on error.

### DIFF
--- a/template.go
+++ b/template.go
@@ -34,7 +34,10 @@ Output:
 */
 func Parse(name, text string) (string, error) {
 	outTpl, err := newTree(name).Parse(text, leftDelim, rightDelim, make(map[string]*tree))
-	return outTpl.String(), err
+	if err != nil {
+		return "", err
+	}
+	return outTpl.String(), nil
 }
 
 func (t *tree) String() string {


### PR DESCRIPTION
If there is an early parse error before a `Root` node is created. The Parse function panics.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x6caa24]

goroutine 71 [running]:
github.com/Joker/jade.(*tree).String(0x0, 0x0, 0x0)
	/home/GO/go/src/github.com/Joker/jade/template.go:41 +0x24
github.com/Joker/jade.Parse(0xc820214250, 0xb, 0xc820618000, 0x54a, 0x0, 0x0, 0x0, 0x0)
	/home/GO/go/src/github.com/Joker/jade/template.go:37 +0x196
......
```
