### PR TITLE
Important fixes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 Copyright (c) 2015, Joker
+Copyright (c) 2020, Gerasimos Maropoulos <kataras2006@hotmail.com>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cmd/jade/go_ast_wstr.go
+++ b/cmd/jade/go_ast_wstr.go
@@ -110,7 +110,7 @@ func (ws *writeStrings) fillConstNode(decl []ast.Decl) {
 		for _, v := range ws.constSlice {
 			constNode.Specs = append(constNode.Specs, &ast.ValueSpec{
 				Names: []*ast.Ident{
-					&ast.Ident{Name: v.name},
+					{Name: v.name},
 				},
 				Values: []ast.Expr{
 					&ast.BasicLit{Kind: 9, Value: "`" + v.str + "`"}, // 9 => string

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0
 	golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/Joker/hpp v1.0.0 h1:65+iuJYdRXv/XyN62C1uEmmOx3432rNG/rKlX6V7Kkc=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
-github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -8,5 +7,4 @@ golang.org/x/net v0.0.0-20190327091125-710a502c58a2 h1:17UhVDrPb40BH5k6cyeb2V/7Q
 golang.org/x/net v0.0.0-20190327091125-710a502c58a2/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf h1:++r/Kj1CfG42p6XntDItK1TfB5V6Vq/baDeKvV1q5gY=
 golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/jade_parse.go
+++ b/jade_parse.go
@@ -444,7 +444,7 @@ func (t *Tree) parseSubFile(path string) *ListNode {
 	var incTree = New(currentTmplDir + path)
 	incTree.block = t.block
 	incTree.mixin = t.mixin
-
+	incTree.ReadFunc = t.ReadFunc
 	_, err := incTree.Parse(t.read(path))
 	if err != nil {
 		d, _ := os.Getwd()

--- a/jade_parse.go
+++ b/jade_parse.go
@@ -440,7 +440,8 @@ func (t *Tree) parseInclude(tk item) *ListNode {
 
 func (t *Tree) parseSubFile(path string) *ListNode {
 	// log.Println("subtemplate: " + path)
-	var incTree = New(path)
+	currentTmplDir, _ := filepath.Split(t.Name)
+	var incTree = New(currentTmplDir + path)
 	incTree.block = t.block
 	incTree.mixin = t.mixin
 


### PR DESCRIPTION
- Do **NOT** change current working directory by any `os.Chdir` call
- Use a smarter way to catch sub templates (no need of `os.Chdir` anymore)
- Fixes force-reading from system directory, add a new `ReadFunc` on `Tree` and a new `NewWithReadFunc` package-level function.

Fixes:

- https://github.com/Joker/jade/issues/33
- https://github.com/kataras/iris/issues/1450