### PR TITLE
New Feature

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,11 +1,8 @@
 package jade
 
-import "io/ioutil"
-
 //go:generate stringer -type=itemType,NodeType -trimprefix=item -output=config_string.go
 
 var TabSize = 4
-var ReadFunc = ioutil.ReadFile
 
 var (
 	golang_mode  = false

--- a/jade_parse.go
+++ b/jade_parse.go
@@ -439,9 +439,8 @@ func (t *tree) parseInclude(tk item) *listNode {
 }
 
 func (t *tree) parseSubFile(path string) *listNode {
-	// log.Println("subtemplate: " + path)
-	currentTmplDir, _ := filepath.Split(t.Name)
-	var incTree = New(currentTmplDir + path)
+	var incTree = New(t.resolvePath(path))
+
 	incTree.block = t.block
 	incTree.mixin = t.mixin
 	_, err := incTree.Parse(t.read(path))
@@ -454,10 +453,9 @@ func (t *tree) parseSubFile(path string) *listNode {
 }
 
 func (t *tree) read(path string) []byte {
-	currentTmplDir, _ := filepath.Split(t.Name)
-	path = currentTmplDir + path
+	path = t.resolvePath(path)
 
-	bb, err := ReadFunc(path)
+	bb, err := ReadFunc(path, t.fileSystem)
 
 	if os.IsNotExist(err) {
 
@@ -472,7 +470,7 @@ func (t *tree) read(path string) []byte {
 			} else {
 				ext = ".jade"
 			}
-			bb, err = ReadFunc(path + ext)
+			bb, err = ReadFunc(path+ext, t.fileSystem)
 		}
 	}
 	if err != nil {
@@ -480,4 +478,9 @@ func (t *tree) read(path string) []byte {
 		t.errorf(`%s  work dir: %s `, err, wd)
 	}
 	return bb
+}
+
+func (t *tree) resolvePath(path string) string {
+	currentTmplDir, _ := filepath.Split(t.Name)
+	return filepath.Clean(currentTmplDir + path)
 }

--- a/parse.go
+++ b/parse.go
@@ -6,14 +6,16 @@ package jade
 
 import (
 	"fmt"
+	"net/http"
 	"runtime"
 )
 
 // Tree is the representation of a single parsed template.
 type tree struct {
-	Name string    // name of the template represented by the tree.
-	Root *listNode // top-level root of the tree.
-	text string    // text parsed to create the template (or its parent)
+	Name       string    // name of the template represented by the tree.
+	Root       *listNode // top-level root of the tree.
+	text       string    // text parsed to create the template (or its parent)
+	fileSystem http.FileSystem
 
 	// Parsing only; cleared after parse.
 	lex       *lexer
@@ -141,5 +143,14 @@ func New(name string) *tree {
 		Name:  name,
 		mixin: map[string]*mixinNode{},
 		block: map[string]*listNode{},
+	}
+}
+
+func NewFileSystem(name string, fs http.FileSystem) *tree {
+	return &tree{
+		Name:       name,
+		fileSystem: fs,
+		mixin:      map[string]*mixinNode{},
+		block:      map[string]*listNode{},
 	}
 }

--- a/template.go
+++ b/template.go
@@ -4,6 +4,8 @@ package jade
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"path/filepath"
 )
 
@@ -48,9 +50,19 @@ func Parse(name string, text []byte) (string, error) {
 	return b.String(), nil
 }
 
+func ParseFileSystem(name string, text []byte, fs http.FileSystem) (string, error) {
+	outTpl, err := NewFileSystem(name, fs).Parse(text)
+	if err != nil {
+		return "", err
+	}
+	b := new(bytes.Buffer)
+	outTpl.WriteIn(b)
+	return b.String(), nil
+}
+
 // ParseFile parse the jade template file in given filename
 func ParseFile(filename string) (string, error) {
-	bs, err := ReadFunc(filename)
+	bs, err := ReadFunc(filename, nil)
 	if err != nil {
 		return "", err
 	}
@@ -59,4 +71,28 @@ func ParseFile(filename string) (string, error) {
 
 func (t *tree) WriteIn(b io.Writer) {
 	t.Root.WriteIn(b)
+}
+
+func ReadFunc(filename string, fs http.FileSystem) ([]byte, error) {
+	if fs == nil {
+		return ioutil.ReadFile(filename)
+	}
+
+	file, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, info.Size())
+	_, err = file.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
 }


### PR DESCRIPTION
## What?
Support http.FileSystem and allow two dots in include path
## Why?
Because include files can be in sibling directories, also support filesystem that goFiber already have 
## How?
- Edit ReadFunc, if non filesystem provided use ioutil.ReadFile, else use the filesystem
- Use filepath.Clean to resolve shortest path
## Testing
Tested both this repo and goFiber/template
## Breaking changes
No