### PR TITLE
Fix nested attributes in mixin

### DIFF
--- a/jade_node.go
+++ b/jade_node.go
@@ -570,6 +570,15 @@ type mixinNode struct {
 func (t *tree) newMixin(pos pos) *mixinNode {
 	return &mixinNode{tr: t, nodeType: nodeMixin, pos: pos}
 }
+func (m *mixinNode) cloneMixin() *mixinNode {
+	return &mixinNode{
+		tr:       m.tr,
+		nodeType: nodeMixin,
+		pos:      m.pos,
+		AttrName: m.AttrName,
+		AttrCode: m.AttrCode,
+	}
+}
 
 func (l *mixinNode) append(n node) {
 	l.Nodes = append(l.Nodes, n)
@@ -630,11 +639,16 @@ func (l *mixinNode) WriteIn(b io.Writer) {
 	fmt.Fprintf(b, mixin__end)
 }
 
-func (l *mixinNode) CopyMixin() *mixinNode {
+func (l *mixinNode) CopyMixin(withAttributes bool) *mixinNode {
 	if l == nil {
 		return l
 	}
-	n := l.tr.newMixin(l.pos)
+	var n *mixinNode
+	if withAttributes {
+		n = l.cloneMixin()
+	} else {
+		n = l.tr.newMixin(l.pos)
+	}
 	for _, elem := range l.Nodes {
 		n.append(elem.Copy())
 	}
@@ -642,7 +656,7 @@ func (l *mixinNode) CopyMixin() *mixinNode {
 }
 
 func (l *mixinNode) Copy() node {
-	return l.CopyMixin()
+	return l.CopyMixin(true)
 }
 
 //

--- a/jade_parse.go
+++ b/jade_parse.go
@@ -354,7 +354,7 @@ func (t *tree) parseMixinUse(tk item) node {
 	}
 	var (
 		deep  = tk.depth
-		mixin = tMix.CopyMixin()
+		mixin = tMix.CopyMixin(false)
 	)
 Loop:
 	for {

--- a/testdata/v2/mixins.go
+++ b/testdata/v2/mixins.go
@@ -178,4 +178,20 @@ func Jade_mixins(buffer *pool.ByteBuffer) {
 		buffer.WriteString(`</ul>`)
 	}
 
+	{
+		var (
+			foo = "My inner paragraph"
+		)
+
+		{
+			var (
+				bar = foo
+			)
+
+			buffer.WriteString(`<p>`)
+			WriteEscString(bar, buffer)
+			buffer.WriteString(`</p>`)
+		}
+	}
+
 }

--- a/testdata/v2/mixins.jade
+++ b/testdata/v2/mixins.jade
@@ -70,3 +70,11 @@ mixin list(id, ...items)
 //- Use
 // TODO for string
 +list(fn("my-list"), "string", 2, 3.5, 4)
+
+//- Declaration
+mixin inner(bar)
+  p= bar
+mixin outer(foo)
+  +inner(foo)
+//- Use
++outer('My inner paragraph')

--- a/testdata/v2/mixins.tpl
+++ b/testdata/v2/mixins.tpl
@@ -61,3 +61,6 @@
     <li>{{ item }}</li>
     {{ end }}
 </ul>
+{{ $foo := "My inner paragraph" }}
+{{ $bar := foo }} 
+<p>{{ bar }}</p>


### PR DESCRIPTION
## Fix

- Fix mixin copy when building nodes. (#54) 

## Test

- Add a simple test case of a nested mixin in `testdata/v2/mixins.*`.

